### PR TITLE
Remove `timingFunction` property because it is ignored

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -21,7 +21,6 @@ extension UIView: CustomViewAnimations {
         animation.values =  [0, 20, -20, 10, 0]
         animation.keyTimes = [0, (1 / 6.0), (3 / 6.0), (5 / 6.0), 1]
         animation.duration = duration
-        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
         animation.additive = true
         
         layer.addAnimation(animation, forKey:"shake")


### PR DESCRIPTION
According to Apple's [Animation Types and Timing Programming Guide](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/Animation_Types_Timing/Articles/PropertyAnimations.html#//apple_ref/doc/uid/TP40006672-SW7), keyframe animations ignore the property `timingFunction`.

Since defining the property does not affect the code's behavior, it could be left in. However, I think it's best to remove it to avoid confusing users of this library.
### EDIT

However, you can provide an array of timing functions to correspond to each key frame with the property [`timingFunctions`](https://developer.apple.com/library/ios/documentation/GraphicsImaging/Reference/CAKeyframeAnimation_class/index.html#//apple_ref/occ/instp/CAKeyframeAnimation/timingFunctions).

> The `timingFunctions` property specifies the timing curves to use for each keyframe segment. (This property replaces the inherited `timingFunction` property.)

[Core Animation Programming Guide](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/CoreAnimation_guide/CreatingBasicAnimations/CreatingBasicAnimations.html#//apple_ref/doc/uid/TP40004514-CH3-SW11)
