### PR TITLE
Add iPhoneX helper

### DIFF
--- a/Sources/UIDevice.swift
+++ b/Sources/UIDevice.swift
@@ -52,6 +52,10 @@ public extension UIDevice {
         return maxScreenLength() == 736
     }
 
+    func iPhoneX() -> Bool {
+        return maxScreenLength() == 812
+    }
+
     /**
      Resize a font according to current device. Works for iPhone apps only. The desired font size will be multiplied by the coefficient for the corresponding current device.
      All coefficients have reasonable default values.

--- a/XLSwiftKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/XLSwiftKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
iPhone 8 and 8 plus have the same sizes as 6, 7 and 6, 7 Plus respectively.

The device size helper functions should still work fine without this change as they default to the size of iPhone 7 Plus with 375x736 while the iPhone X is 375x812
