### PR TITLE
Convenience utilities for point/size/vector arithmetic

### DIFF
--- a/Sources/Overload2D.swift
+++ b/Sources/Overload2D.swift
@@ -1,0 +1,278 @@
+import CoreGraphics
+
+/// Arithmetic extensions for CGPoint, CGSize, and CGVector.
+/// All of the operators +, -, *, /, and unary minus are supported. Where
+/// applicable, operators can be applied to point/size/vector + point/size/vector,
+/// as well as point/size/vector + CGFloat and CGFloat + point/size/vector.
+protocol Overload2D {
+    /// Really for internal use, but publicly available so the unit tests can use them.
+    var a: CGFloat { get set }
+    var b: CGFloat { get set }
+
+    /// So we can create any one of our types without needing argument names
+    /// - Parameters:
+    ///   - x: depending on the object being created, this is the x-coordinate,
+    ///        or the width, or the dx component
+    ///   - y: depending on the object being created, this is the y-coordinate,
+    ///        or the height, or the dy component
+    init(_ x: CGFloat, _ y: CGFloat)
+
+    /// Convenience function for easy conversion to CGPoint from the others,
+    /// to make arithmetic operations between the types easier to write and read.
+    func asPoint() -> CGPoint
+    /// Convenience function for easy conversion to CGSize from the others,
+    /// to make arithmetic operations between the types easier to write and read.
+    func asSize() -> CGSize
+    /// Convenience function for easy conversion to CGVector from the others,
+    /// to make arithmetic operations between the types easier to write and read.
+    func asVector() -> CGVector
+
+    /// So we can create any one of our types without needing argument names
+    ///
+    /// Same functionality as init(_:,_:)
+    ///
+    /// - Parameters:
+    ///   - x: depending on the object being created, this is the x-coordinate,
+    ///        or the width, or the dx component
+    ///   - y: depending on the object being created, this is the y-coordinate,
+    ///        or the height, or the dy component
+    static func makeTuple(_ x: CGFloat, _ y: CGFloat) -> Self
+
+    /// Unary minus: negates both scalars in the tuple
+    static prefix func - (_ myself: Self) -> Self
+
+    /// Basic arithmetic with tuples on both sides of the operator.
+    /// These return a new tuple with lhsTuple.0 (op) rhsTuple.0, lhsTuple.1 (op) rhsTuple.1.
+    ///
+    /// Examples:
+    ///
+    /// CGPoint(x: 10, y: 3) + CGPoint(17, 37) = CGPoint(x: 10 + 17, y: 3 + 37)
+    ///
+    /// CGSize(width: 5, height: 7) * CGSize(width: 12, height: 13) = CGSize(width: 5 * 12, height: 7 * 13)
+    static func + (_ lhs: Self, _ rhs: Self) -> Self
+    static func - (_ lhs: Self, _ rhs: Self) -> Self
+    static func * (_ lhs: Self, _ rhs: Self) -> Self
+    static func / (_ lhs: Self, _ rhs: Self) -> Self
+
+    /// Basic arithmetic with tuple (op) CGFloat, or CGFloat (op) tuple
+    /// These return a new tuple with lhsTuple.0 (op) rhs, lhsTuple.1 (op) rhs.
+    ///
+    /// Examples:
+    ///
+    /// CGPoint(x: 10, y: 3) / 42 = CGPoint(x: 10 / 42, y: 3 / 42)
+    ///
+    /// CGSize(width: 5, height: 7) - 137 = CGSize(width: 5 - 137, height: 7 - 137)
+    static func + (_ lhs: Self, _ rhs: CGFloat) -> Self
+    static func - (_ lhs: Self, _ rhs: CGFloat) -> Self
+    static func * (_ lhs: Self, _ rhs: CGFloat) -> Self
+    static func / (_ lhs: Self, _ rhs: CGFloat) -> Self
+
+    static func + (_ lhs: CGFloat, _ rhs: Self) -> Self
+    static func - (_ lhs: CGFloat, _ rhs: Self) -> Self
+    static func * (_ lhs: CGFloat, _ rhs: Self) -> Self
+    static func / (_ lhs: CGFloat, _ rhs: Self) -> Self
+
+    /// Compound assignment operators. These all work the same as the basic operators,
+    /// applying compound assignment the same as the usual arithmetic versions.
+    static func += (_ lhs: inout Self, _ rhs: Self)
+    static func -= (_ lhs: inout Self, _ rhs: Self)
+    static func *= (_ lhs: inout Self, _ rhs: Self)
+    static func /= (_ lhs: inout Self, _ rhs: Self)
+
+    static func += (_ lhs: inout Self, _ rhs: CGFloat)
+    static func -= (_ lhs: inout Self, _ rhs: CGFloat)
+    static func *= (_ lhs: inout Self, _ rhs: CGFloat)
+    static func /= (_ lhs: inout Self, _ rhs: CGFloat)
+}
+
+// MARK: Implementations
+
+extension Overload2D {
+    static prefix func - (_ myself: Self) -> Self {
+        return myself * -1.0
+    }
+
+    static func + (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.a + rhs.a, lhs.b + rhs.b)
+    }
+    static func - (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.a - rhs.a, lhs.b - rhs.b)
+    }
+    static func * (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.a * rhs.a, lhs.b * rhs.b)
+    }
+    static func / (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.a / rhs.a, lhs.b / rhs.b)
+    }
+
+    static func + (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.a + rhs, lhs.b + rhs)
+    }
+    static func - (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.a - rhs, lhs.b - rhs)
+    }
+    static func * (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.a * rhs, lhs.b * rhs)
+    }
+    static func / (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.a / rhs, lhs.b / rhs)
+    }
+
+    static func + (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs + rhs.a, lhs + rhs.b)
+    }
+    static func - (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs - rhs.a, lhs - rhs.b)
+    }
+    static func * (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs * rhs.a, lhs * rhs.b)
+    }
+    static func / (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs / rhs.a, lhs / rhs.b)
+    }
+
+    static func += (_ lhs: inout Self, _ rhs: Self) {
+        lhs.a += rhs.a; lhs.b += rhs.b
+    }
+    static func -= (_ lhs: inout Self, _ rhs: Self) {
+        lhs.a -= rhs.a; lhs.b -= rhs.b
+    }
+    static func *= (_ lhs: inout Self, _ rhs: Self) {
+        lhs.a *= rhs.a; lhs.b *= rhs.b
+    }
+    static func /= (_ lhs: inout Self, _ rhs: Self) {
+        lhs.a /= rhs.a; lhs.b /= rhs.b
+    }
+
+    static func += (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.a += rhs; lhs.b += rhs
+    }
+    static func -= (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.a -= rhs; lhs.b -= rhs
+    }
+    static func *= (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.a *= rhs; lhs.b *= rhs
+    }
+    static func /= (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.a /= rhs; lhs.b /= rhs
+    }
+}
+
+extension CGPoint: Overload2D {
+    var a: CGFloat { get { return self.x } set { self.x = newValue } }
+    var b: CGFloat { get { return self.y } set { self.y = newValue } }
+
+    init(_ x: CGFloat, _ y: CGFloat) {
+        self.init(x: x, y: y)
+    }
+
+    static func makeTuple(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+        return CGPoint(x: x, y: y)
+    }
+
+    static func makeTuple(_ x: CGFloat, _ y: CGFloat) -> CGSize {
+        return CGSize.makeTuple(x, y)
+    }
+
+    static func makeTuple(_ x: CGFloat, _ y: CGFloat) -> CGVector {
+        return CGVector.makeTuple(x, y)
+    }
+
+    func asPoint() -> CGPoint {
+        return CGPoint(x: x, y: y)
+    }
+
+    func asSize() -> CGSize {
+        return CGSize(width: x, height: y)
+    }
+
+    func asVector() -> CGVector {
+        return CGVector(dx: x, dy: y)
+    }
+}
+
+extension CGSize: Overload2D {
+    var a: CGFloat { get { return self.width } set { self.width = newValue } }
+    var b: CGFloat { get { return self.height } set { self.height = newValue } }
+
+    init(_ width: CGFloat, _ height: CGFloat) {
+        self.init(width: width, height: height)
+    }
+
+    static func makeTuple(_ width: CGFloat, _ height: CGFloat) -> CGPoint {
+        return CGPoint.makeTuple(width, height)
+    }
+
+    static func makeTuple(_ width: CGFloat, _ height: CGFloat) -> CGSize {
+        return CGSize(width: width, height: height)
+    }
+
+    static func makeTuple(_ width: CGFloat, _ height: CGFloat) -> CGVector {
+        return CGVector.makeTuple(width, height)
+    }
+
+    func asPoint() -> CGPoint {
+        return CGPoint(x: width, y: height)
+    }
+
+    func asSize() -> CGSize {
+        return CGSize(width: width, height: height)
+    }
+
+    func asVector() -> CGVector {
+        return CGVector(dx: width, dy: height)
+    }
+}
+
+extension CGVector: Overload2D {
+    var a: CGFloat { get { return self.dx } set { self.dx = newValue } }
+    var b: CGFloat { get { return self.dy } set { self.dy = newValue } }
+
+    init(_ dx: CGFloat, _ dy: CGFloat) {
+        self.init(dx: dx, dy: dy)
+    }
+
+    static func makeTuple(_ dx: CGFloat, _ dy: CGFloat) -> CGPoint {
+        return CGPoint.makeTuple(dx, dy)
+    }
+
+    static func makeTuple(_ dx: CGFloat, _ dy: CGFloat) -> CGSize {
+        return CGSize.makeTuple(dx, dy)
+    }
+
+    static func makeTuple(_ dx: CGFloat, _ dy: CGFloat) -> CGVector {
+        return CGVector(dx: dx, dy: dy)
+    }
+
+    func asPoint() -> CGPoint {
+        return CGPoint(x: dx, y: dy)
+    }
+
+    func asSize() -> CGSize {
+        return CGSize(width: dx, height: dy)
+    }
+
+    func asVector() -> CGVector {
+        return CGVector(dx: dx, dy: dy)
+    }
+}
+
+extension CGVector {
+    func magnitude() -> CGFloat {
+        return sqrt(dx * dx + dy * dy)
+    }
+}
+
+extension CGPoint {
+    func distance(to otherPoint: CGPoint) -> CGFloat {
+        return CGVector(dx: otherPoint.x, dy: otherPoint.y).magnitude()
+    }
+
+    static func random(range: Range<CGFloat>) -> CGPoint {
+        return CGPoint(x: CGFloat.random(in: range), y: CGFloat.random(in: range))
+    }
+
+    static func random(xRange: Range<CGFloat>, yRange: Range<CGFloat>) -> CGPoint {
+        return CGPoint(x: CGFloat.random(in: xRange), y: CGFloat.random(in: yRange))
+    }
+}

--- a/Tests/TestOverload2D/TestByReference_OpScalar.swift
+++ b/Tests/TestOverload2D/TestByReference_OpScalar.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+typealias NTuple2 = (a: CGFloat, b: CGFloat)
+
+class TestOverload2D: XCTestCase {
+    enum Operation { case add, subtract, multiply, divide }
+    enum OperandType { case point, size, vector }
+
+    struct TestEntry_PassByReference_OpScalar {
+        let aResult: CGFloat
+        let bResult: CGFloat
+
+        let lhs: (CGFloat, CGFloat)
+        let rhs: CGFloat
+
+        let operation: Operation
+
+        init(_ operation: Operation,
+             _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat,
+             _ aResult: CGFloat, _ bResult: CGFloat
+            ) {
+            self.lhs = lhs; self.rhs = rhs; self.operation = operation
+            self.aResult = aResult; self.bResult = bResult
+        }
+    }
+
+    func operate(_ operation: Operation, _ operandType: OperandType,
+                 _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat)
+        -> (CGFloat, CGFloat)
+    {
+        switch operation {
+        case .add:
+            switch operandType {
+            case .point:
+                var p = CGPoint(x: lhs.0, y: lhs.1); p += rhs; return (p.x, p.y)
+
+            case .size:
+                var s = CGSize(width: lhs.0, height: lhs.1); s += rhs; return (s.width, s.height)
+
+            case .vector:
+                var v = CGVector(dx: lhs.0, dy: lhs.1); v += rhs; return (v.dx, v.dy)
+            }
+
+        case .subtract:
+            switch operandType {
+            case .point:
+                var p = CGPoint(x: lhs.0, y: lhs.1); p -= rhs; return (p.x, p.y)
+
+            case .size:
+                var s = CGSize(width: lhs.0, height: lhs.1); s -= rhs; return (s.width, s.height)
+
+            case .vector:
+                var v = CGVector(dx: lhs.0, dy: lhs.1); v -= rhs; return (v.dx, v.dy)
+            }
+
+        case .multiply:
+            switch operandType {
+            case .point:
+                var p = CGPoint(x: lhs.0, y: lhs.1); p *= rhs; return (p.x, p.y)
+
+            case .size:
+                var s = CGSize(width: lhs.0, height: lhs.1); s *= rhs; return (s.width, s.height)
+
+            case .vector:
+                var v = CGVector(dx: lhs.0, dy: lhs.1); v *= rhs; return (v.dx, v.dy)
+            }
+
+        case .divide:
+            switch operandType {
+            case .point:
+                var p = CGPoint(x: lhs.0, y: lhs.1); p /= rhs; return (p.x, p.y)
+
+            case .size:
+                var s = CGSize(width: lhs.0, height: lhs.1); s /= rhs; return (s.width, s.height)
+
+            case .vector:
+                var v = CGVector(dx: lhs.0, dy: lhs.1); v /= rhs; return (v.dx, v.dy)
+            }
+        }
+    }
+
+    func testPassByReference_OpScalar() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+        let zero: (CGFloat, CGFloat) = (0.0, 0.0)
+
+        continueAfterFailure = false
+        XCTAssert(a != 0 && b != 0 && c != 0 && d != 0,
+                  "Run again; got a zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByReference = [
+            TestEntry_PassByReference_OpScalar(.add, zero, a, a, a),
+            TestEntry_PassByReference_OpScalar(.add, (a, b), c, a + c, b + c),
+            TestEntry_PassByReference_OpScalar(.add, (d, c), b, d + b, c + b),
+
+            TestEntry_PassByReference_OpScalar(.subtract, zero, a, -a, -a),
+            TestEntry_PassByReference_OpScalar(.subtract, (a, b), c, a - c, b - c),
+            TestEntry_PassByReference_OpScalar(.subtract, (d, c), b, d - b, c - b),
+
+            TestEntry_PassByReference_OpScalar(.multiply, zero, a, 0, 0),
+            TestEntry_PassByReference_OpScalar(.multiply, (a, b), c, a * c, b * c),
+            TestEntry_PassByReference_OpScalar(.multiply, (d, c), b, d * b, c * b),
+
+            TestEntry_PassByReference_OpScalar(.divide, zero, a, 0, 0),
+            TestEntry_PassByReference_OpScalar(.divide, (a, b), c, a / c, b / c),
+            TestEntry_PassByReference_OpScalar(.divide, (d, c), b, d / b, c / b),
+        ]
+
+        testSetForPassByReference.forEach { testEntry in
+            let p = (testEntry.lhs.0, testEntry.lhs.1)
+            let s = (testEntry.lhs.0, testEntry.lhs.1)
+            let v = (testEntry.lhs.0, testEntry.lhs.1)
+
+            let pr = operate(testEntry.operation, .point, p, testEntry.rhs)
+            XCTAssertEqual(CGPoint(x: pr.0, y: pr.1), CGPoint(x: testEntry.aResult, y: testEntry.bResult))
+
+            let sr = operate(testEntry.operation, .size, s, testEntry.rhs)
+            XCTAssertEqual(CGSize(width: sr.0, height: sr.1), CGSize(width: testEntry.aResult, height: testEntry.bResult))
+
+            let vr = operate(testEntry.operation, .vector, v, testEntry.rhs)
+            XCTAssertEqual(CGVector(dx: vr.0, dy: vr.1), CGVector(dx: testEntry.aResult, dy: testEntry.bResult))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestByReference_OpTuple.swift
+++ b/Tests/TestOverload2D/TestByReference_OpTuple.swift
@@ -1,0 +1,149 @@
+import XCTest
+
+extension TestOverload2D {
+    struct TestEntry_PassByReference_OpTuple {
+        let lhs: (CGFloat, CGFloat)
+        let rhs: (CGFloat, CGFloat)
+        let result: (CGFloat, CGFloat)
+
+        let operation: Operation
+
+        init(_ operation: Operation,
+             _ lhs: (CGFloat, CGFloat), _ rhs: (CGFloat, CGFloat),
+             _ result: (CGFloat, CGFloat)
+            ) {
+            self.lhs = lhs; self.rhs = rhs; self.operation = operation; self.result = result
+        }
+    }
+
+    func operate(_ operation: Operation, _ operandType: OperandType,
+                 _ lhs: (CGFloat, CGFloat), _ rhs: (CGFloat, CGFloat)
+        )
+
+        -> (CGFloat, CGFloat) {
+            switch operation {
+            case .add:
+                switch operandType {
+                case .point:
+                    var p = CGPoint(x: lhs.0, y: lhs.1)
+                    p += CGPoint(x: rhs.0, y: rhs.1)
+                    return (p.x, p.y)
+
+                case .size:
+                    var s = CGSize(width: lhs.0, height: lhs.1)
+                    s += CGSize(width: rhs.0, height: rhs.1)
+                    return (s.width, s.height)
+
+                case .vector:
+                    var v = CGVector(dx: lhs.0, dy: lhs.1)
+                    v += CGVector(dx: rhs.0, dy: rhs.1)
+                    return (v.dx, v.dy)
+                }
+
+            case .subtract:
+                switch operandType {
+                case .point:
+                    var p = CGPoint(x: lhs.0, y: lhs.1)
+                    p -= CGPoint(x: rhs.0, y: rhs.1)
+                    return (p.x, p.y)
+
+                case .size:
+                    var s = CGSize(width: lhs.0, height: lhs.1)
+                    s -= CGSize(width: rhs.0, height: rhs.1)
+                    return (s.width, s.height)
+
+                case .vector:
+                    var v = CGVector(dx: lhs.0, dy: lhs.1)
+                    v -= CGVector(dx: rhs.0, dy: rhs.1)
+                    return (v.dx, v.dy)
+                }
+
+            case .multiply:
+                switch operandType {
+                case .point:
+                    var p = CGPoint(x: lhs.0, y: lhs.1)
+                    p *= CGPoint(x: rhs.0, y: rhs.1)
+                    return (p.x, p.y)
+
+                case .size:
+                    var s = CGSize(width: lhs.0, height: lhs.1)
+                    s *= CGSize(width: rhs.0, height: rhs.1)
+                    return (s.width, s.height)
+
+                case .vector:
+                    var v = CGVector(dx: lhs.0, dy: lhs.1)
+                    v *= CGVector(dx: rhs.0, dy: rhs.1)
+                    return (v.dx, v.dy)
+                }
+
+            case .divide:
+                switch operandType {
+                case .point:
+                    var p = CGPoint(x: lhs.0, y: lhs.1)
+                    p /= CGPoint(x: rhs.0, y: rhs.1)
+                    return (p.x, p.y)
+
+                case .size:
+                    var s = CGSize(width: lhs.0, height: lhs.1)
+                    s /= CGSize(width: rhs.0, height: rhs.1)
+                    return (s.width, s.height)
+
+                case .vector:
+                    var v = CGVector(dx: lhs.0, dy: lhs.1)
+                    v /= CGVector(dx: rhs.0, dy: rhs.1)
+                    return (v.dx, v.dy)
+                }
+            }
+    }
+
+    func testPassByReference_OpTuple() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+        let zero: (CGFloat, CGFloat) = (0.0, 0.0)
+
+        continueAfterFailure = false
+        XCTAssert(a != 0 && b != 0 && c != 0 && d != 0,
+                  "Run again; got a zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByReference = [
+            TestEntry_PassByReference_OpTuple(.add, zero, (a, b), (a, b)),
+            TestEntry_PassByReference_OpTuple(.add, (a, b), (c, d), (a + c, b + d)),
+            TestEntry_PassByReference_OpTuple(.add, (d, c), (b, a), (d + b, c + a)),
+
+            TestEntry_PassByReference_OpTuple(.subtract, zero, (a, b), (-a, -b)),
+            TestEntry_PassByReference_OpTuple(.subtract, (a, b), (c, d), (a - c, b - d)),
+            TestEntry_PassByReference_OpTuple(.subtract, (d, c), (b, a), (d - b, c - a)),
+
+            TestEntry_PassByReference_OpTuple(.multiply, zero, (a, b), (0, 0)),
+            TestEntry_PassByReference_OpTuple(.multiply, (a, b), (c, d), (a * c, b * d)),
+            TestEntry_PassByReference_OpTuple(.multiply, (d, c), (b, a), (d * b, c * a)),
+
+            TestEntry_PassByReference_OpTuple(.divide, zero, (a, b), (0, 0)),
+            TestEntry_PassByReference_OpTuple(.divide, (a, b), (c, d), (a / c, b / d)),
+            TestEntry_PassByReference_OpTuple(.divide, (d, c), (b, a), (d / b, c / a)),
+        ]
+
+        testSetForPassByReference.forEach { testEntry in
+            let lhsP = (testEntry.lhs.0, testEntry.lhs.1)
+            let rhsP = (testEntry.rhs.0, testEntry.rhs.1)
+
+            let lhsS = (testEntry.lhs.0, testEntry.lhs.1)
+            let rhsS = (testEntry.rhs.0, testEntry.rhs.1)
+
+            let lhsV = (testEntry.lhs.0, testEntry.lhs.1)
+            let rhsV = (testEntry.rhs.0, testEntry.rhs.1)
+
+            let pr = operate(testEntry.operation, .point, lhsP, rhsP)
+            XCTAssertEqual(CGPoint(x: pr.0, y: pr.1), CGPoint(x: testEntry.result.0, y: testEntry.result.1))
+
+            let sr = operate(testEntry.operation, .size, lhsS, rhsS)
+            XCTAssertEqual(CGSize(width: sr.0, height: sr.1), CGSize(width: testEntry.result.0, height: testEntry.result.1))
+
+            let vr = operate(testEntry.operation, .vector, lhsV, rhsV)
+            XCTAssertEqual(CGVector(dx: vr.0, dy: vr.1), CGVector(dx: testEntry.result.0, dy: testEntry.result.1))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestByValue_OpScalar.swift
+++ b/Tests/TestOverload2D/TestByValue_OpScalar.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+extension TestOverload2D {
+
+    struct TestEntry_PassByValue_OpScalar {
+        let aResult: CGFloat
+        let bResult: CGFloat
+
+        let lhs: NTuple2
+        let rhs: CGFloat
+
+        let operation: (CGFloat, CGFloat) -> CGFloat
+
+        init(
+            _ lhs: NTuple2, _ operation: @escaping (CGFloat, CGFloat) -> CGFloat,
+            _ rhs: CGFloat, _ aResult: CGFloat, _ bResult: CGFloat
+            ) {
+            self.lhs = lhs; self.rhs = rhs; self.operation = operation
+            self.aResult = aResult; self.bResult = bResult
+        }
+    }
+
+    func testPassByValue_OpScalar() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+        let zero = CGFloat(0.0)
+
+        continueAfterFailure = false
+        XCTAssert(a != 0 && b != 0 && c != 0 && d != 0,
+                  "Run again; got a zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByValue = [
+            TestEntry_PassByValue_OpScalar((zero, zero), +, a, a, a),
+            TestEntry_PassByValue_OpScalar((a, b), +, c, a + c, b + c),
+            TestEntry_PassByValue_OpScalar((d, c), +, b, d + b, c + b),
+
+            TestEntry_PassByValue_OpScalar((zero, zero), -, a, -a, -a),
+            TestEntry_PassByValue_OpScalar((a, b), -, c, a - c, b - c),
+            TestEntry_PassByValue_OpScalar((d, c), -, a, d - a, c - a),
+
+            TestEntry_PassByValue_OpScalar((zero, zero), *, a, 0, 0),
+            TestEntry_PassByValue_OpScalar((a, b), *, c, a * c, b * c),
+            TestEntry_PassByValue_OpScalar((d, c), *, a, d * a, c * a),
+
+            TestEntry_PassByValue_OpScalar((zero, zero), /, a, 0, 0),
+            TestEntry_PassByValue_OpScalar((a, b), /, c, a / c, b / c),
+            TestEntry_PassByValue_OpScalar((d, c), /, b, d / b, c / b)
+        ]
+
+        testSetForPassByValue.forEach { testEntry in
+            let p = CGPoint(
+                x: testEntry.operation(testEntry.lhs.0, testEntry.rhs),
+                y: testEntry.operation(testEntry.lhs.1, testEntry.rhs)
+            )
+
+            let s = CGSize(
+                width: testEntry.operation(testEntry.lhs.0, testEntry.rhs),
+                height: testEntry.operation(testEntry.lhs.1, testEntry.rhs)
+            )
+
+            let v = CGVector(
+                dx: testEntry.operation(testEntry.lhs.0, testEntry.rhs),
+                dy: testEntry.operation(testEntry.lhs.1, testEntry.rhs)
+            )
+
+            XCTAssertEqual(p, CGPoint(x:    testEntry.aResult, y:      testEntry.bResult))
+            XCTAssertEqual(s, CGSize(width: testEntry.aResult, height: testEntry.bResult))
+            XCTAssertEqual(v, CGVector(dx:  testEntry.aResult, dy:     testEntry.bResult))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestByValue_OpTuple.swift
+++ b/Tests/TestOverload2D/TestByValue_OpTuple.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+extension TestOverload2D {
+
+    struct TestEntry_PassByValue_OpTuple {
+        let aResult: CGFloat
+        let bResult: CGFloat
+
+        let lhs: NTuple2
+        let rhs: NTuple2
+
+        let operation: (CGFloat, CGFloat) -> CGFloat
+
+        init(
+            _ lhs: NTuple2, _ operation: @escaping (CGFloat, CGFloat) -> CGFloat, _ rhs: NTuple2,
+            _ aResult: CGFloat, _ bResult: CGFloat
+            ) {
+            self.lhs = lhs; self.rhs = rhs;
+            self.operation = operation
+            self.aResult = aResult; self.bResult = bResult
+        }
+    }
+
+    func testPassByValue_OpTuple() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+        let zero = CGFloat(0.0)
+
+        continueAfterFailure = false
+        XCTAssert(a != 0 && b != 0 && c != 0 && d != 0,
+                  "Run again; got a zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByValue = [
+            TestEntry_PassByValue_OpTuple((zero, zero), +, (a, b), zero + a, zero + b),
+            TestEntry_PassByValue_OpTuple((a, b), +, (c, d), a + c, b + d),
+            TestEntry_PassByValue_OpTuple((d, c), +, (b, a), d + b, c + a),
+
+            TestEntry_PassByValue_OpTuple((zero, zero), -, (a, b), zero - a, zero - b),
+            TestEntry_PassByValue_OpTuple((a, b), -, (c, d), a - c, b - d),
+            TestEntry_PassByValue_OpTuple((d, c), -, (b, a), d - b, c - a),
+
+            TestEntry_PassByValue_OpTuple((zero, zero), *, (a, b), zero * a, zero * b),
+            TestEntry_PassByValue_OpTuple((a, b), *, (c, d), a * c, b * d),
+            TestEntry_PassByValue_OpTuple((d, c), *, (b, a), d * b, c * a),
+
+            TestEntry_PassByValue_OpTuple((zero, zero), /, (a, b), zero / a, zero / b),
+            TestEntry_PassByValue_OpTuple((a, b), /, (c, d), a / c, b / d),
+            TestEntry_PassByValue_OpTuple((d, c), /, (b, a), d / b, c / a),
+        ]
+
+        testSetForPassByValue.forEach { testEntry in
+            let p = CGPoint(
+                x: testEntry.operation(testEntry.lhs.0, testEntry.rhs.0),
+                y: testEntry.operation(testEntry.lhs.1, testEntry.rhs.1)
+            )
+
+            let s = CGSize(
+                width: testEntry.operation(testEntry.lhs.0, testEntry.rhs.0),
+                height: testEntry.operation(testEntry.lhs.1, testEntry.rhs.1)
+            )
+
+            let v = CGVector(
+                dx: testEntry.operation(testEntry.lhs.0, testEntry.rhs.0),
+                dy: testEntry.operation(testEntry.lhs.1, testEntry.rhs.1)
+            )
+
+            XCTAssertEqual(p, CGPoint(x:    testEntry.aResult, y:      testEntry.bResult))
+            XCTAssertEqual(s, CGSize(width: testEntry.aResult, height: testEntry.bResult))
+            XCTAssertEqual(v, CGVector(dx:  testEntry.aResult, dy:     testEntry.bResult))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestMiscellaneous.swift
+++ b/Tests/TestOverload2D/TestMiscellaneous.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+extension TestOverload2D {
+
+    func testUnaryMinus() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+
+        continueAfterFailure = false
+        XCTAssert(a != 0 && b != 0 && c != 0 && d != 0,
+                  "Run again; got a zero random number, won't work for division")
+        continueAfterFailure = true
+
+        XCTAssertEqual(-CGPoint(x: a, y: b), CGPoint(x: -a, y: -b))
+        XCTAssertEqual(-CGSize(width: b, height: c), CGSize(width: -b, height: -c))
+        XCTAssertEqual(-CGVector(dx: c, dy: d), CGVector(dx: -c, dy: -d))
+    }
+
+    func testAsOther() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+
+        continueAfterFailure = false
+        XCTAssert(a != 0 && b != 0 && c != 0 && d != 0,
+                  "Run again; got a zero random number, won't work for division")
+        continueAfterFailure = true
+
+        XCTAssertEqual(CGPoint(x: a, y: b), CGSize(width: a, height: b).asPoint())
+        XCTAssertEqual(CGPoint(x: a, y: b), CGVector(dx: a, dy: b).asPoint())
+
+        XCTAssertEqual(CGSize(width: b, height: c), CGPoint(x: b, y: c).asSize())
+        XCTAssertEqual(CGSize(width: b, height: c), CGVector(dx: b, dy: c).asSize())
+
+        XCTAssertEqual(CGVector(dx: c, dy: d), CGPoint(x: c, y: d).asVector())
+        XCTAssertEqual(CGVector(dx: c, dy: d), CGSize(width: c, height: d).asVector())
+    }
+
+    func testCombinations() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+
+        let p = CGPoint(x: a, y: b) +
+            2 * CGVector(dx: b, dy: c).asPoint() -
+            (3 * CGSize(width: c, height: d)).asPoint()
+
+        XCTAssertEqual(p, CGPoint(x: a + 2 * b - 3 * c, y: b + 2 * c - 3 * d))
+
+        let s = CGSize(width: a, height: b) +
+            4 * CGVector(dx: b, dy: c).asSize() -
+            (5 * CGPoint(x: c, y: d)).asSize()
+
+        XCTAssertEqual(s, CGSize(width: a + 4 * b - 5 * c, height: b + 4 * c - 5 * d))
+
+        let v = CGVector(dx: a, dy: b) +
+            6 * CGSize(width: b, height: c).asVector() -
+            (7 * CGPoint(x: c, y: d)).asVector()
+
+        XCTAssertEqual(v, CGVector(dx: a + 6 * b - 7 * c, dy: b + 6 * c - 7 * d))
+
+    }
+
+    func testOtherWithCombinations() {
+        let a = CGFloat.random(in: -1000...1000)
+        let b = CGFloat.random(in: -1000...1000)
+        let c = CGFloat.random(in: -1000...1000)
+        let d = CGFloat.random(in: -1000...1000)
+
+        var p = CGPoint(x: d, y: a).asVector().asSize().asPoint()
+        p *= CGPoint(x: a, y: b).asVector().asPoint().asSize().asPoint()
+        p /= CGPoint(x: b, y: c).asSize().asPoint().asSize().asPoint()
+        p += CGPoint(x: c, y: d).asSize().asVector().asPoint().asVector().asSize().asPoint()
+
+        XCTAssertEqual(p, CGPoint(x: ((d * a) / b) + c, y: ((a * b) / c) + d))
+
+        var s = CGSize(width: d, height: a).asVector().asPoint().asSize()
+        s /= CGSize(width: a, height: b).asVector().asPoint().asVector().asSize()
+        s += CGSize(width: b, height: c).asPoint().asVector().asPoint().asSize()
+        s *= CGSize(width: c, height: d).asSize().asVector().asSize().asPoint().asVector().asSize()
+
+        XCTAssertEqual(s, CGSize(width: ((d / a) + b) * c, height: ((a / b) + c) * d))
+
+        var v = CGVector(dx: d, dy: a).asSize().asPoint().asVector()
+        v += CGVector(dx: a, dy: b).asPoint().asVector().asSize().asVector()
+        v *= CGVector(dx: b, dy: c).asPoint().asVector().asPoint().asVector()
+        v /= CGVector(dx: c, dy: d).asSize().asVector().asPoint().asVector().asSize().asPoint().asVector()
+
+        XCTAssertEqual(v, CGVector(dx: ((d + a) * b) / c, dy: ((a + b) * c) / d))
+    }
+}

--- a/XLSwiftKit.xcodeproj/project.pbxproj
+++ b/XLSwiftKit.xcodeproj/project.pbxproj
@@ -45,6 +45,13 @@
 		BF7E0BFF1C6E554700D831DD /* DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0BBD1C6E53E400D831DD /* DictionaryTests.swift */; };
 		BF7E0C001C6E554700D831DD /* UIColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0BBE1C6E53E400D831DD /* UIColorTests.swift */; };
 		BF7E0C011C6E554700D831DD /* GCDHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0BBF1C6E53E400D831DD /* GCDHelperTests.swift */; };
+		D489677C22495BCD000F5D15 /* Overload2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677B22495BCD000F5D15 /* Overload2D.swift */; };
+		D489678422495C38000F5D15 /* TestByReference_OpTuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677E22495C38000F5D15 /* TestByReference_OpTuple.swift */; };
+		D489678522495C38000F5D15 /* TestByValue_OpTuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677F22495C38000F5D15 /* TestByValue_OpTuple.swift */; };
+		D489678622495C38000F5D15 /* TestMiscellaneous.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489678022495C38000F5D15 /* TestMiscellaneous.swift */; };
+		D489678722495C38000F5D15 /* TestByValue_OpScalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489678122495C38000F5D15 /* TestByValue_OpScalar.swift */; };
+		D489678922495C38000F5D15 /* TestByReference_OpScalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489678322495C38000F5D15 /* TestByReference_OpScalar.swift */; };
+		D489678A22495C59000F5D15 /* Overload2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677B22495BCD000F5D15 /* Overload2D.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +106,12 @@
 		BF7E0BDA1C6E53F300D831DD /* UINavigationBar+Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Swift.h"; sourceTree = "<group>"; };
 		BF7E0BDC1C6E53F300D831DD /* XLFoundationSwiftKit-Bridgin-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XLFoundationSwiftKit-Bridgin-Header.h"; sourceTree = "<group>"; };
 		BF7E0BDD1C6E53F300D831DD /* XLFoundationSwiftKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XLFoundationSwiftKit.h; sourceTree = "<group>"; };
+		D489677B22495BCD000F5D15 /* Overload2D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Overload2D.swift; sourceTree = "<group>"; };
+		D489677E22495C38000F5D15 /* TestByReference_OpTuple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByReference_OpTuple.swift; sourceTree = "<group>"; };
+		D489677F22495C38000F5D15 /* TestByValue_OpTuple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByValue_OpTuple.swift; sourceTree = "<group>"; };
+		D489678022495C38000F5D15 /* TestMiscellaneous.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMiscellaneous.swift; sourceTree = "<group>"; };
+		D489678122495C38000F5D15 /* TestByValue_OpScalar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByValue_OpScalar.swift; sourceTree = "<group>"; };
+		D489678322495C38000F5D15 /* TestByReference_OpScalar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByReference_OpScalar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +164,7 @@
 		28F8288B1C494B2C00330CF4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D489677D22495C38000F5D15 /* TestOverload2D */,
 				8F52939C1D8C52BD00143015 /* DataTests.swift */,
 				BF7E0BBD1C6E53E400D831DD /* DictionaryTests.swift */,
 				BF7E0BBF1C6E53E400D831DD /* GCDHelperTests.swift */,
@@ -205,6 +219,7 @@
 				28A6B9C71CB5E28700682BCE /* NSData.swift */,
 				BF7E0BC81C6E53F300D831DD /* NSDate.swift */,
 				BF7E0BCF1C6E53F300D831DD /* Numbers.swift */,
+				D489677B22495BCD000F5D15 /* Overload2D.swift */,
 				46BD3DFD1D74CCAF00D93B2F /* ParametrizedString.swift */,
 				BF7E0BD01C6E53F300D831DD /* String.swift */,
 				BF7E0BC91C6E53F300D831DD /* UIApplication.swift */,
@@ -231,6 +246,19 @@
 			);
 			name = Helpers;
 			sourceTree = "<group>";
+		};
+		D489677D22495C38000F5D15 /* TestOverload2D */ = {
+			isa = PBXGroup;
+			children = (
+				D489677E22495C38000F5D15 /* TestByReference_OpTuple.swift */,
+				D489677F22495C38000F5D15 /* TestByValue_OpTuple.swift */,
+				D489678322495C38000F5D15 /* TestByReference_OpScalar.swift */,
+				D489678122495C38000F5D15 /* TestByValue_OpScalar.swift */,
+				D489678022495C38000F5D15 /* TestMiscellaneous.swift */,
+			);
+			name = TestOverload2D;
+			path = Tests/TestOverload2D;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
@@ -373,6 +401,7 @@
 				46BD3DFA1D74BF8200D93B2F /* OwnerView.swift in Sources */,
 				BF7E0BEE1C6E53F300D831DD /* UIColor.swift in Sources */,
 				BF7E0BE31C6E53F300D831DD /* UIViewController.swift in Sources */,
+				D489677C22495BCD000F5D15 /* Overload2D.swift in Sources */,
 				BF68CCC21C74F2A5006BE94B /* Box.swift in Sources */,
 				BF7E0BE41C6E53F300D831DD /* AFImageExtension.swift in Sources */,
 				BF7E0BEC1C6E53F300D831DD /* Dictionary.swift in Sources */,
@@ -394,14 +423,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D489678422495C38000F5D15 /* TestByReference_OpTuple.swift in Sources */,
 				BF7E0BFF1C6E554700D831DD /* DictionaryTests.swift in Sources */,
 				BF7E0BFC1C6E554700D831DD /* NumberTests.swift in Sources */,
 				BF7E0BFE1C6E554700D831DD /* UIImageTests.swift in Sources */,
 				BF7E0BFD1C6E554700D831DD /* StringTests.swift in Sources */,
+				D489678722495C38000F5D15 /* TestByValue_OpScalar.swift in Sources */,
 				BF7E0BFB1C6E554000D831DD /* NSDateTests.swift in Sources */,
 				BF7E0C011C6E554700D831DD /* GCDHelperTests.swift in Sources */,
+				D489678622495C38000F5D15 /* TestMiscellaneous.swift in Sources */,
 				BF7E0C001C6E554700D831DD /* UIColorTests.swift in Sources */,
+				D489678522495C38000F5D15 /* TestByValue_OpTuple.swift in Sources */,
+				D489678A22495C59000F5D15 /* Overload2D.swift in Sources */,
 				8F52939E1D8C530E00143015 /* DataTests.swift in Sources */,
+				D489678922495C38000F5D15 /* TestByReference_OpScalar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XLSwiftKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/XLSwiftKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
A protocol and some extensions to the CoreGraphics 2D representations `CGPoint`, `CGSize`, and `CGVector` to enable easy conversion from one to the other, as well as arithmetic.

Functions are available for arithmetic on `CG... (op) CG...` as well as `CG... (op) CGFloat` and `CGFloat (op) CG...`.

- For the first form, `CG... (op) CG...`, the components are combined like 2D vectors:
   - `CGPoint(x: 42, y: 117) + CGPoint(x: 137, y: 9) = CGPoint(x: 42 + 137, y: 117 + 9)`
- For the second and third forms, the scalar is added to each component of the CG object:
   - `CGVector(dx: 11, dy: 21) * 5 = CGVector(dx: 11 * 5, dy: 21 * 5)`
   - `7 * CGSize(width: 3, height: 4) = CGSize(width: 7 * 3, height: 7 * 4)`

Conversion functions are available on all three types: `asPoint()`, `asSize()`, `asVector()`:
- `CGPoint(x: 10, y: 11).asSize() / 14 = CGSize(width: 10 / 14, height: 11 / 14)`
- `CGSize(width: 3, height: 4).asVector() - CGVector(dx: 4, dy: 3) = CGVector(dx: 3 - 4, dy: 4 - 3)`

Unary minus is supported; it behaves the same as with scalars, multiplying both components by -1. For example,` -CGPoint(x: 32, y: 44) = CGPoint(x -32, y: -44)`

Compound assignment is supported:

    var p = CGPoint(x: 9, y: 17)
    p *= CGPoint(104, 91) 
    precondition(p == CGPoint(x: 9 * 104, y: 17 * 91)

    var v = 21 * CGVector(dx: 7, dy: 13)
    v /= 13
    precondition(v == CGVector(dx: 21 * 7 / 13, dy: 21 * 13 / 13)