### PR TITLE
Overload2D protocol for point/size/vector arithmetic

### DIFF
--- a/Sources/Overload2D.swift
+++ b/Sources/Overload2D.swift
@@ -1,0 +1,298 @@
+import CoreGraphics
+
+/// Arithmetic extensions for CGPoint, CGSize, and CGVector.
+/// All of the operators +, -, *, /, and unary minus are supported. Where
+/// applicable, operators can be applied to point/size/vector + point/size/vector,
+/// as well as point/size/vector + CGFloat and CGFloat + point/size/vector.
+protocol Overload2D {
+    /// Really for internal use, but publicly available so the unit tests can use them.
+    var aa: CGFloat { get set }
+    var bb: CGFloat { get set }
+
+    /// So we can create any one of our types without needing argument names
+    /// - Parameters:
+    ///   - xx: depending on the object being created, this is the x-coordinate,
+    ///        or the width, or the dx component
+    ///   - yy: depending on the object being created, this is the y-coordinate,
+    ///        or the height, or the dy component
+    init(_ xx: CGFloat, _ yy: CGFloat)
+
+    /// Convenience function for easy conversion to CGPoint from the others,
+    /// to make arithmetic operations between the types easier to write and read.
+    func asPoint() -> CGPoint
+    /// Convenience function for easy conversion to CGSize from the others,
+    /// to make arithmetic operations between the types easier to write and read.
+    func asSize() -> CGSize
+    /// Convenience function for easy conversion to CGVector from the others,
+    /// to make arithmetic operations between the types easier to write and read.
+    func asVector() -> CGVector
+
+    /// So we can create any one of our types without needing argument names
+    ///
+    /// Same functionality as init(_:,_:)
+    ///
+    /// - Parameters:
+    ///   - x: depending on the object being created, this is the x-coordinate,
+    ///        or the width, or the dx component
+    ///   - y: depending on the object being created, this is the y-coordinate,
+    ///        or the height, or the dy component
+    static func makeTuple(_ xx: CGFloat, _ yy: CGFloat) -> Self
+
+    /// Unary minus: negates both scalars in the tuple
+    static prefix func - (_ myself: Self) -> Self
+
+    /// Basic arithmetic with tuples on both sides of the operator.
+    /// These return a new tuple with lhsTuple.0 (op) rhsTuple.0, lhsTuple.1 (op) rhsTuple.1.
+    ///
+    /// Examples:
+    ///
+    /// CGPoint(x: 10, y: 3) + CGPoint(17, 37) = CGPoint(x: 10 + 17, y: 3 + 37)
+    ///
+    /// CGSize(width: 5, height: 7) * CGSize(width: 12, height: 13) = CGSize(width: 5 * 12, height: 7 * 13)
+    static func + (_ lhs: Self, _ rhs: Self) -> Self
+    static func - (_ lhs: Self, _ rhs: Self) -> Self
+    static func * (_ lhs: Self, _ rhs: Self) -> Self
+    static func / (_ lhs: Self, _ rhs: Self) -> Self
+
+    /// Basic arithmetic with tuple (op) CGFloat, or CGFloat (op) tuple
+    /// These return a new tuple with lhsTuple.0 (op) rhs, lhsTuple.1 (op) rhs.
+    ///
+    /// Examples:
+    ///
+    /// CGPoint(x: 10, y: 3) / 42 = CGPoint(x: 10 / 42, y: 3 / 42)
+    ///
+    /// CGSize(width: 5, height: 7) - 137 = CGSize(width: 5 - 137, height: 7 - 137)
+    static func + (_ lhs: Self, _ rhs: CGFloat) -> Self
+    static func - (_ lhs: Self, _ rhs: CGFloat) -> Self
+    static func * (_ lhs: Self, _ rhs: CGFloat) -> Self
+    static func / (_ lhs: Self, _ rhs: CGFloat) -> Self
+
+    static func + (_ lhs: CGFloat, _ rhs: Self) -> Self
+    static func - (_ lhs: CGFloat, _ rhs: Self) -> Self
+    static func * (_ lhs: CGFloat, _ rhs: Self) -> Self
+    static func / (_ lhs: CGFloat, _ rhs: Self) -> Self
+
+    /// Compound assignment operators. These all work the same as the basic operators,
+    /// applying compound assignment the same as the usual arithmetic versions.
+    static func += (_ lhs: inout Self, _ rhs: Self)
+    static func -= (_ lhs: inout Self, _ rhs: Self)
+    static func *= (_ lhs: inout Self, _ rhs: Self)
+    static func /= (_ lhs: inout Self, _ rhs: Self)
+
+    static func += (_ lhs: inout Self, _ rhs: CGFloat)
+    static func -= (_ lhs: inout Self, _ rhs: CGFloat)
+    static func *= (_ lhs: inout Self, _ rhs: CGFloat)
+    static func /= (_ lhs: inout Self, _ rhs: CGFloat)
+}
+
+// MARK: Implementations
+
+extension Overload2D {
+    static prefix func - (_ myself: Self) -> Self {
+        return myself * -1.0
+    }
+
+    static func + (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.aa + rhs.aa, lhs.bb + rhs.bb)
+    }
+    static func - (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.aa - rhs.aa, lhs.bb - rhs.bb)
+    }
+    static func * (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.aa * rhs.aa, lhs.bb * rhs.bb)
+    }
+    static func / (_ lhs: Self, _ rhs: Self) -> Self {
+        return makeTuple(lhs.aa / rhs.aa, lhs.bb / rhs.bb)
+    }
+
+    static func + (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.aa + rhs, lhs.bb + rhs)
+    }
+    static func - (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.aa - rhs, lhs.bb - rhs)
+    }
+    static func * (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.aa * rhs, lhs.bb * rhs)
+    }
+    static func / (_ lhs: Self, _ rhs: CGFloat) -> Self {
+        return makeTuple(lhs.aa / rhs, lhs.bb / rhs)
+    }
+
+    static func + (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs + rhs.aa, lhs + rhs.bb)
+    }
+    static func - (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs - rhs.aa, lhs - rhs.bb)
+    }
+    static func * (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs * rhs.aa, lhs * rhs.bb)
+    }
+    static func / (_ lhs: CGFloat, _ rhs: Self) -> Self {
+        return makeTuple(lhs / rhs.aa, lhs / rhs.bb)
+    }
+
+    static func += (_ lhs: inout Self, _ rhs: Self) {
+        lhs.aa += rhs.aa; lhs.bb += rhs.bb
+    }
+    static func -= (_ lhs: inout Self, _ rhs: Self) {
+        lhs.aa -= rhs.aa; lhs.bb -= rhs.bb
+    }
+    static func *= (_ lhs: inout Self, _ rhs: Self) {
+        lhs.aa *= rhs.aa; lhs.bb *= rhs.bb
+    }
+    static func /= (_ lhs: inout Self, _ rhs: Self) {
+        lhs.aa /= rhs.aa; lhs.bb /= rhs.bb
+    }
+
+    static func += (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.aa += rhs; lhs.bb += rhs
+    }
+    static func -= (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.aa -= rhs; lhs.bb -= rhs
+    }
+    static func *= (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.aa *= rhs; lhs.bb *= rhs
+    }
+    static func /= (_ lhs: inout Self, _ rhs: CGFloat) {
+        lhs.aa /= rhs; lhs.bb /= rhs
+    }
+}
+
+extension Overload2D where Self == CGVector {
+    func magnitude() -> CGFloat {
+        return sqrt(self.dx * self.dx + self.dy * self.dy)
+    }
+}
+
+extension Overload2D where Self == CGPoint {
+    func distance(to otherPoint: CGPoint) -> CGFloat {
+        return (otherPoint - self).asVector().magnitude()
+    }
+
+    static func random(in range: Range<CGFloat>) -> CGPoint {
+        return CGPoint(x: CGFloat.random(in: range), y: CGFloat.random(in: range))
+    }
+
+    static func random(xRange: Range<CGFloat>, yRange: Range<CGFloat>) -> CGPoint {
+        return CGPoint(x: CGFloat.random(in: xRange), y: CGFloat.random(in: yRange))
+    }
+}
+
+extension Overload2D where Self == CGSize {
+    static func random(in range: Range<CGFloat>) -> CGSize {
+        return CGSize(width: CGFloat.random(in: range), height: CGFloat.random(in: range))
+    }
+
+    static func random(widthRange: Range<CGFloat>, heightRange: Range<CGFloat>) -> CGSize {
+        return CGSize(width: CGFloat.random(in: widthRange), height: CGFloat.random(in: heightRange))
+    }
+}
+
+extension Overload2D where Self == CGVector {
+    static func random(in range: Range<CGFloat>) -> CGVector {
+        return CGVector(dx: CGFloat.random(in: range), dy: CGFloat.random(in: range))
+    }
+
+    static func random(dxRange: Range<CGFloat>, dyRange: Range<CGFloat>) -> CGVector {
+        return CGVector(dx: CGFloat.random(in: dxRange), dy: CGFloat.random(in: dyRange))
+    }
+}
+
+extension CGPoint: Overload2D {
+    var aa: CGFloat { get { return self.x } set { self.x = newValue } }
+    var bb: CGFloat { get { return self.y } set { self.y = newValue } }
+
+    init(_ xx: CGFloat, _ yy: CGFloat) {
+        self.init(x: xx, y: yy)
+    }
+
+    static func makeTuple(_ xx: CGFloat, _ yy: CGFloat) -> CGPoint {
+        return CGPoint(x: xx, y: yy)
+    }
+
+    static func makeTuple(_ xx: CGFloat, _ yy: CGFloat) -> CGSize {
+        return CGSize.makeTuple(xx, yy)
+    }
+
+    static func makeTuple(_ xx: CGFloat, _ yy: CGFloat) -> CGVector {
+        return CGVector.makeTuple(xx, yy)
+    }
+
+    func asPoint() -> CGPoint {
+        return CGPoint(x: x, y: y)
+    }
+
+    func asSize() -> CGSize {
+        return CGSize(width: x, height: y)
+    }
+
+    func asVector() -> CGVector {
+        return CGVector(dx: x, dy: y)
+    }
+}
+
+extension CGSize: Overload2D {
+    var aa: CGFloat { get { return self.width } set { self.width = newValue } }
+    var bb: CGFloat { get { return self.height } set { self.height = newValue } }
+
+    init(_ width: CGFloat, _ height: CGFloat) {
+        self.init(width: width, height: height)
+    }
+
+    static func makeTuple(_ width: CGFloat, _ height: CGFloat) -> CGPoint {
+        return CGPoint.makeTuple(width, height)
+    }
+
+    static func makeTuple(_ width: CGFloat, _ height: CGFloat) -> CGSize {
+        return CGSize(width: width, height: height)
+    }
+
+    static func makeTuple(_ width: CGFloat, _ height: CGFloat) -> CGVector {
+        return CGVector.makeTuple(width, height)
+    }
+
+    func asPoint() -> CGPoint {
+        return CGPoint(x: width, y: height)
+    }
+
+    func asSize() -> CGSize {
+        return CGSize(width: width, height: height)
+    }
+
+    func asVector() -> CGVector {
+        return CGVector(dx: width, dy: height)
+    }
+}
+
+extension CGVector: Overload2D {
+    var aa: CGFloat { get { return self.dx } set { self.dx = newValue } }
+    var bb: CGFloat { get { return self.dy } set { self.dy = newValue } }
+
+    init(_ dx: CGFloat, _ dy: CGFloat) {
+        self.init(dx: dx, dy: dy)
+    }
+
+    static func makeTuple(_ dx: CGFloat, _ dy: CGFloat) -> CGPoint {
+        return CGPoint.makeTuple(dx, dy)
+    }
+
+    static func makeTuple(_ dx: CGFloat, _ dy: CGFloat) -> CGSize {
+        return CGSize.makeTuple(dx, dy)
+    }
+
+    static func makeTuple(_ dx: CGFloat, _ dy: CGFloat) -> CGVector {
+        return CGVector(dx: dx, dy: dy)
+    }
+
+    func asPoint() -> CGPoint {
+        return CGPoint(x: dx, y: dy)
+    }
+
+    func asSize() -> CGSize {
+        return CGSize(width: dx, height: dy)
+    }
+
+    func asVector() -> CGVector {
+        return CGVector(dx: dx, dy: dy)
+    }
+}

--- a/Tests/TestOverload2D/TestByReference_OpScalar.swift
+++ b/Tests/TestOverload2D/TestByReference_OpScalar.swift
@@ -1,0 +1,139 @@
+import XCTest
+
+typealias NTuple2 = (aa: CGFloat, bb: CGFloat)
+
+class TestOverload2D: XCTestCase {
+    enum Operation { case add, subtract, multiply, divide }
+    enum OperandType { case point, size, vector }
+
+    struct TestEntry_PassByReference_OpScalar {
+        let aResult: CGFloat
+        let bResult: CGFloat
+
+        let lhs: (CGFloat, CGFloat)
+        let rhs: CGFloat
+
+        let operation: Operation
+
+        init(_ operation: Operation,
+             _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat,
+             _ aResult: CGFloat, _ bResult: CGFloat
+            ) {
+            self.lhs = lhs; self.rhs = rhs; self.operation = operation
+            self.aResult = aResult; self.bResult = bResult
+        }
+    }
+
+    private func operate_add(_ operandType: OperandType,
+                             _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat) -> (CGFloat, CGFloat) {
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1); pp += rhs; return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1); ss += rhs; return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1); vv += rhs; return (vv.dx, vv.dy)
+        }
+    }
+
+    func operate_subtract(_ operandType: OperandType,
+                          _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat)
+        -> (CGFloat, CGFloat) {
+            switch operandType {
+            case .point:
+                var pp = CGPoint(x: lhs.0, y: lhs.1); pp -= rhs; return (pp.x, pp.y)
+
+            case .size:
+                var ss = CGSize(width: lhs.0, height: lhs.1); ss -= rhs; return (ss.width, ss.height)
+
+            case .vector:
+                var vv = CGVector(dx: lhs.0, dy: lhs.1); vv -= rhs; return (vv.dx, vv.dy)
+            }
+    }
+
+    func operate_multiply(_ operandType: OperandType,
+                          _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat) -> (CGFloat, CGFloat) {
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1); pp *= rhs; return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1); ss *= rhs; return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1); vv *= rhs; return (vv.dx, vv.dy)
+        }
+    }
+
+    func operate_divide(_ operandType: OperandType,
+                        _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat) -> (CGFloat, CGFloat) {
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1); pp /= rhs; return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1); ss /= rhs; return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1); vv /= rhs; return (vv.dx, vv.dy)
+        }
+    }
+
+    func operate(_ operation: Operation, _ operandType: OperandType,
+                 _ lhs: (CGFloat, CGFloat), _ rhs: CGFloat) -> (CGFloat, CGFloat) {
+        switch operation {
+        case .add: return operate_add(operandType, lhs, rhs)
+        case .subtract: return operate_subtract(operandType, lhs, rhs)
+        case .multiply: return operate_multiply(operandType, lhs, rhs)
+        case .divide: return operate_divide(operandType, lhs, rhs)
+        }
+    }
+
+    func testPassByReference_OpScalar() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+        let zero: (CGFloat, CGFloat) = (0.0, 0.0)
+
+        continueAfterFailure = false
+        XCTAssert(aa != 0 && bb != 0 && cc != 0 && dd != 0,
+                  "Run again; got aa zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByReference = [
+            TestEntry_PassByReference_OpScalar(.add, zero, aa, aa, aa),
+            TestEntry_PassByReference_OpScalar(.add, (aa, bb), cc, aa + cc, bb + cc),
+            TestEntry_PassByReference_OpScalar(.add, (dd, cc), bb, dd + bb, cc + bb),
+
+            TestEntry_PassByReference_OpScalar(.subtract, zero, aa, -aa, -aa),
+            TestEntry_PassByReference_OpScalar(.subtract, (aa, bb), cc, aa - cc, bb - cc),
+            TestEntry_PassByReference_OpScalar(.subtract, (dd, cc), bb, dd - bb, cc - bb),
+
+            TestEntry_PassByReference_OpScalar(.multiply, zero, aa, 0, 0),
+            TestEntry_PassByReference_OpScalar(.multiply, (aa, bb), cc, aa * cc, bb * cc),
+            TestEntry_PassByReference_OpScalar(.multiply, (dd, cc), bb, dd * bb, cc * bb),
+
+            TestEntry_PassByReference_OpScalar(.divide, zero, aa, 0, 0),
+            TestEntry_PassByReference_OpScalar(.divide, (aa, bb), cc, aa / cc, bb / cc),
+            TestEntry_PassByReference_OpScalar(.divide, (dd, cc), bb, dd / bb, cc / bb)
+        ]
+
+        testSetForPassByReference.forEach { testEntry in
+            let pp = (testEntry.lhs.0, testEntry.lhs.1)
+            let ss = (testEntry.lhs.0, testEntry.lhs.1)
+            let vv = (testEntry.lhs.0, testEntry.lhs.1)
+
+            let pr = operate(testEntry.operation, .point, pp, testEntry.rhs)
+            XCTAssertEqual(CGPoint(x: pr.0, y: pr.1), CGPoint(x: testEntry.aResult, y: testEntry.bResult))
+
+            let sr = operate(testEntry.operation, .size, ss, testEntry.rhs)
+            XCTAssertEqual(CGSize(width: sr.0, height: sr.1), CGSize(width: testEntry.aResult, height: testEntry.bResult))
+
+            let vr = operate(testEntry.operation, .vector, vv, testEntry.rhs)
+            XCTAssertEqual(CGVector(dx: vr.0, dy: vr.1), CGVector(dx: testEntry.aResult, dy: testEntry.bResult))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestByReference_OpTuple.swift
+++ b/Tests/TestOverload2D/TestByReference_OpTuple.swift
@@ -1,0 +1,177 @@
+import XCTest
+
+extension TestOverload2D {
+    struct TestEntry_PassByReference_OpTuple {
+        let lhs: (CGFloat, CGFloat)
+        let rhs: (CGFloat, CGFloat)
+        let result: (CGFloat, CGFloat)
+
+        let operation: Operation
+
+        init(_ operation: Operation,
+             _ lhs: (CGFloat, CGFloat), _ rhs: (CGFloat, CGFloat),
+             _ result: (CGFloat, CGFloat)
+            ) {
+            self.lhs = lhs; self.rhs = rhs; self.operation = operation; self.result = result
+        }
+    }
+
+    private func operation_add(
+        _ operandType: OperandType,
+        _ lhs: (CGFloat, CGFloat),
+        _ rhs: (CGFloat, CGFloat)
+        ) -> (CGFloat, CGFloat) {
+
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1)
+            pp += CGPoint(x: rhs.0, y: rhs.1)
+            return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1)
+            ss += CGSize(width: rhs.0, height: rhs.1)
+            return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1)
+            vv += CGVector(dx: rhs.0, dy: rhs.1)
+            return (vv.dx, vv.dy)
+        }
+
+    }
+
+    private func operation_subtract(
+        _ operandType: OperandType,
+        _ lhs: (CGFloat, CGFloat),
+        _ rhs: (CGFloat, CGFloat)
+        ) -> (CGFloat, CGFloat) {
+
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1)
+            pp -= CGPoint(x: rhs.0, y: rhs.1)
+            return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1)
+            ss -= CGSize(width: rhs.0, height: rhs.1)
+            return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1)
+            vv -= CGVector(dx: rhs.0, dy: rhs.1)
+            return (vv.dx, vv.dy)
+        }
+
+    }
+
+    private func operation_multiply(
+        _ operandType: OperandType,
+        _ lhs: (CGFloat, CGFloat),
+        _ rhs: (CGFloat, CGFloat)
+        ) -> (CGFloat, CGFloat) {
+
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1)
+            pp *= CGPoint(x: rhs.0, y: rhs.1)
+            return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1)
+            ss *= CGSize(width: rhs.0, height: rhs.1)
+            return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1)
+            vv *= CGVector(dx: rhs.0, dy: rhs.1)
+            return (vv.dx, vv.dy)
+        }
+    }
+
+    private func operation_divide(
+        _ operandType: OperandType,
+        _ lhs: (CGFloat, CGFloat),
+        _ rhs: (CGFloat, CGFloat)
+        ) -> (CGFloat, CGFloat) {
+
+        switch operandType {
+        case .point:
+            var pp = CGPoint(x: lhs.0, y: lhs.1)
+            pp /= CGPoint(x: rhs.0, y: rhs.1)
+            return (pp.x, pp.y)
+
+        case .size:
+            var ss = CGSize(width: lhs.0, height: lhs.1)
+            ss /= CGSize(width: rhs.0, height: rhs.1)
+            return (ss.width, ss.height)
+
+        case .vector:
+            var vv = CGVector(dx: lhs.0, dy: lhs.1)
+            vv /= CGVector(dx: rhs.0, dy: rhs.1)
+            return (vv.dx, vv.dy)
+        }
+    }
+
+    func operate(_ operation: Operation, _ operandType: OperandType,
+                 _ lhs: (CGFloat, CGFloat), _ rhs: (CGFloat, CGFloat)) -> (CGFloat, CGFloat) {
+        switch operation {
+        case .add: return operation_add(operandType, lhs, rhs)
+        case .subtract: return operation_subtract(operandType, lhs, rhs)
+        case .multiply: return operation_multiply(operandType, lhs, rhs)
+        case .divide: return operation_divide(operandType, lhs, rhs)
+        }
+    }
+
+    func testPassByReference_OpTuple() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+        let zero: (CGFloat, CGFloat) = (0.0, 0.0)
+
+        continueAfterFailure = false
+        XCTAssert(aa != 0 && bb != 0 && cc != 0 && dd != 0,
+                  "Run again; got aa zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByReference = [
+            TestEntry_PassByReference_OpTuple(.add, zero, (aa, bb), (aa, bb)),
+            TestEntry_PassByReference_OpTuple(.add, (aa, bb), (cc, dd), (aa + cc, bb + dd)),
+            TestEntry_PassByReference_OpTuple(.add, (dd, cc), (bb, aa), (dd + bb, cc + aa)),
+
+            TestEntry_PassByReference_OpTuple(.subtract, zero, (aa, bb), (-aa, -bb)),
+            TestEntry_PassByReference_OpTuple(.subtract, (aa, bb), (cc, dd), (aa - cc, bb - dd)),
+            TestEntry_PassByReference_OpTuple(.subtract, (dd, cc), (bb, aa), (dd - bb, cc - aa)),
+
+            TestEntry_PassByReference_OpTuple(.multiply, zero, (aa, bb), (0, 0)),
+            TestEntry_PassByReference_OpTuple(.multiply, (aa, bb), (cc, dd), (aa * cc, bb * dd)),
+            TestEntry_PassByReference_OpTuple(.multiply, (dd, cc), (bb, aa), (dd * bb, cc * aa)),
+
+            TestEntry_PassByReference_OpTuple(.divide, zero, (aa, bb), (0, 0)),
+            TestEntry_PassByReference_OpTuple(.divide, (aa, bb), (cc, dd), (aa / cc, bb / dd)),
+            TestEntry_PassByReference_OpTuple(.divide, (dd, cc), (bb, aa), (dd / bb, cc / aa))
+        ]
+
+        testSetForPassByReference.forEach { testEntry in
+            let lhsP = (testEntry.lhs.0, testEntry.lhs.1)
+            let rhsP = (testEntry.rhs.0, testEntry.rhs.1)
+
+            let lhsS = (testEntry.lhs.0, testEntry.lhs.1)
+            let rhsS = (testEntry.rhs.0, testEntry.rhs.1)
+
+            let lhsV = (testEntry.lhs.0, testEntry.lhs.1)
+            let rhsV = (testEntry.rhs.0, testEntry.rhs.1)
+
+            let pr = operate(testEntry.operation, .point, lhsP, rhsP)
+            XCTAssertEqual(CGPoint(x: pr.0, y: pr.1), CGPoint(x: testEntry.result.0, y: testEntry.result.1))
+
+            let sr = operate(testEntry.operation, .size, lhsS, rhsS)
+            XCTAssertEqual(CGSize(width: sr.0, height: sr.1), CGSize(width: testEntry.result.0, height: testEntry.result.1))
+
+            let vr = operate(testEntry.operation, .vector, lhsV, rhsV)
+            XCTAssertEqual(CGVector(dx: vr.0, dy: vr.1), CGVector(dx: testEntry.result.0, dy: testEntry.result.1))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestByValue_OpScalar.swift
+++ b/Tests/TestOverload2D/TestByValue_OpScalar.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+extension TestOverload2D {
+
+    struct TestEntry_PassByValue_OpScalar {
+        let aResult: CGFloat
+        let bResult: CGFloat
+
+        let lhs: NTuple2
+        let rhs: CGFloat
+
+        let operation: (CGFloat, CGFloat) -> CGFloat
+
+        init(
+            _ lhs: NTuple2, _ operation: @escaping (CGFloat, CGFloat) -> CGFloat,
+            _ rhs: CGFloat, _ aResult: CGFloat, _ bResult: CGFloat
+            ) {
+            self.lhs = lhs; self.rhs = rhs; self.operation = operation
+            self.aResult = aResult; self.bResult = bResult
+        }
+    }
+
+    func testPassByValue_OpScalar() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let ccc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+        let zero = CGFloat(0.0)
+
+        continueAfterFailure = false
+        XCTAssert(aa != 0 && bb != 0 && ccc != 0 && dd != 0,
+                  "Run again; got aa zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByValue = [
+            TestEntry_PassByValue_OpScalar((zero, zero), +, aa, aa, aa),
+            TestEntry_PassByValue_OpScalar((aa, bb), +, ccc, aa + ccc, bb + ccc),
+            TestEntry_PassByValue_OpScalar((dd, ccc), +, bb, dd + bb, ccc + bb),
+
+            TestEntry_PassByValue_OpScalar((zero, zero), -, aa, -aa, -aa),
+            TestEntry_PassByValue_OpScalar((aa, bb), -, ccc, aa - ccc, bb - ccc),
+            TestEntry_PassByValue_OpScalar((dd, ccc), -, aa, dd - aa, ccc - aa),
+
+            TestEntry_PassByValue_OpScalar((zero, zero), *, aa, 0, 0),
+            TestEntry_PassByValue_OpScalar((aa, bb), *, ccc, aa * ccc, bb * ccc),
+            TestEntry_PassByValue_OpScalar((dd, ccc), *, aa, dd * aa, ccc * aa),
+
+            TestEntry_PassByValue_OpScalar((zero, zero), /, aa, 0, 0),
+            TestEntry_PassByValue_OpScalar((aa, bb), /, ccc, aa / ccc, bb / ccc),
+            TestEntry_PassByValue_OpScalar((dd, ccc), /, bb, dd / bb, ccc / bb)
+        ]
+
+        testSetForPassByValue.forEach { testEntry in
+            let pp = CGPoint(
+                x: testEntry.operation(testEntry.lhs.0, testEntry.rhs),
+                y: testEntry.operation(testEntry.lhs.1, testEntry.rhs)
+            )
+
+            let ss = CGSize(
+                width: testEntry.operation(testEntry.lhs.0, testEntry.rhs),
+                height: testEntry.operation(testEntry.lhs.1, testEntry.rhs)
+            )
+
+            let vv = CGVector(
+                dx: testEntry.operation(testEntry.lhs.0, testEntry.rhs),
+                dy: testEntry.operation(testEntry.lhs.1, testEntry.rhs)
+            )
+
+            XCTAssertEqual(pp, CGPoint(x: testEntry.aResult, y: testEntry.bResult))
+            XCTAssertEqual(ss, CGSize(width: testEntry.aResult, height: testEntry.bResult))
+            XCTAssertEqual(vv, CGVector(dx: testEntry.aResult, dy: testEntry.bResult))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestByValue_OpTuple.swift
+++ b/Tests/TestOverload2D/TestByValue_OpTuple.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+extension TestOverload2D {
+
+    struct TestEntry_PassByValue_OpTuple {
+        let aResult: CGFloat
+        let bResult: CGFloat
+
+        let lhs: NTuple2
+        let rhs: NTuple2
+
+        let operation: (CGFloat, CGFloat) -> CGFloat
+
+        init(
+            _ lhs: NTuple2, _ operation: @escaping (CGFloat, CGFloat) -> CGFloat, _ rhs: NTuple2,
+            _ aResult: CGFloat, _ bResult: CGFloat
+            ) {
+            self.lhs = lhs; self.rhs = rhs
+            self.operation = operation
+            self.aResult = aResult; self.bResult = bResult
+        }
+    }
+
+    func testPassByValue_OpTuple() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+        let zero = CGFloat(0.0)
+
+        continueAfterFailure = false
+        XCTAssert(aa != 0 && bb != 0 && cc != 0 && dd != 0,
+                  "Run again; got aa zero random number, won't work for division")
+        continueAfterFailure = true
+
+        let testSetForPassByValue = [
+            TestEntry_PassByValue_OpTuple((zero, zero), +, (aa, bb), zero + aa, zero + bb),
+            TestEntry_PassByValue_OpTuple((aa, bb), +, (cc, dd), aa + cc, bb + dd),
+            TestEntry_PassByValue_OpTuple((dd, cc), +, (bb, aa), dd + bb, cc + aa),
+
+            TestEntry_PassByValue_OpTuple((zero, zero), -, (aa, bb), zero - aa, zero - bb),
+            TestEntry_PassByValue_OpTuple((aa, bb), -, (cc, dd), aa - cc, bb - dd),
+            TestEntry_PassByValue_OpTuple((dd, cc), -, (bb, aa), dd - bb, cc - aa),
+
+            TestEntry_PassByValue_OpTuple((zero, zero), *, (aa, bb), zero * aa, zero * bb),
+            TestEntry_PassByValue_OpTuple((aa, bb), *, (cc, dd), aa * cc, bb * dd),
+            TestEntry_PassByValue_OpTuple((dd, cc), *, (bb, aa), dd * bb, cc * aa),
+
+            TestEntry_PassByValue_OpTuple((zero, zero), /, (aa, bb), zero / aa, zero / bb),
+            TestEntry_PassByValue_OpTuple((aa, bb), /, (cc, dd), aa / cc, bb / dd),
+            TestEntry_PassByValue_OpTuple((dd, cc), /, (bb, aa), dd / bb, cc / aa)
+        ]
+
+        testSetForPassByValue.forEach { testEntry in
+            let pp = CGPoint(
+                x: testEntry.operation(testEntry.lhs.0, testEntry.rhs.0),
+                y: testEntry.operation(testEntry.lhs.1, testEntry.rhs.1)
+            )
+
+            let ss = CGSize(
+                width: testEntry.operation(testEntry.lhs.0, testEntry.rhs.0),
+                height: testEntry.operation(testEntry.lhs.1, testEntry.rhs.1)
+            )
+
+            let vv = CGVector(
+                dx: testEntry.operation(testEntry.lhs.0, testEntry.rhs.0),
+                dy: testEntry.operation(testEntry.lhs.1, testEntry.rhs.1)
+            )
+
+            XCTAssertEqual(pp, CGPoint(x: testEntry.aResult, y: testEntry.bResult))
+            XCTAssertEqual(ss, CGSize(width: testEntry.aResult, height: testEntry.bResult))
+            XCTAssertEqual(vv, CGVector(dx: testEntry.aResult, dy: testEntry.bResult))
+        }
+    }
+}

--- a/Tests/TestOverload2D/TestMiscellaneous.swift
+++ b/Tests/TestOverload2D/TestMiscellaneous.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+extension TestOverload2D {
+
+    func testHypoteneusesAndRandomizers() {
+        let aa = CGPoint.random(in: CGFloat(-1000.0)..<CGFloat(1000.0))
+        let bb = CGPoint.random(in: CGFloat(-1000.0)..<CGFloat(1000.0))
+        let cc = CGSize.random(in: CGFloat(-1000.0)..<CGFloat(1000.0))
+        let dd = CGVector.random(in: CGFloat(-1000.0)..<CGFloat(1000.0))
+
+        let ccSquared = (bb.x - aa.x) * (bb.x - aa.x) + (bb.y - aa.y) * (bb.y - aa.y)
+        let distanceAtoB = sqrt(ccSquared)
+        let hypoteneuseC = sqrt(cc.width * cc.width + cc.height * cc.height)
+        let magnitudeD = sqrt(dd.dx * dd.dx + dd.dy * dd.dy)
+
+        XCTAssertEqual(magnitudeD, sqrt(dd.dx * dd.dx + dd.dy * dd.dy))
+        XCTAssertEqual(CGVector(dx: 1.0, dy: 1.0).magnitude(), sqrt(2.0))
+        XCTAssertEqual(CGVector(dx: 3.0, dy: 4.0).magnitude(), 5.0)
+
+        XCTAssertEqual(hypoteneuseC, sqrt(cc.width * cc.width + cc.height * cc.height))
+        XCTAssertEqual(
+            CGSize(width: 1.0, height: 1.0).asPoint().distance(to: CGSize.zero.asPoint()), sqrt(2.0)
+        )
+
+        XCTAssertEqual(CGPoint(x: 3.0, y: 4.0).distance(to: CGSize.zero.asPoint()), 5)
+
+        XCTAssertEqual(
+            distanceAtoB,
+            sqrt((bb.x - aa.x) * (bb.x - aa.x) + (bb.y - aa.y) * (bb.y - aa.y))
+        )
+
+        XCTAssertEqual(CGPoint(x: 1.0, y: 1.0).distance(to: CGPoint.zero), sqrt(2.0))
+        XCTAssertEqual(CGPoint(x: 3.0, y: 4.0).distance(to: CGPoint.zero), 5)
+    }
+
+    func testUnaryMinus() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+
+        continueAfterFailure = false
+        XCTAssert(aa != 0 && bb != 0 && cc != 0 && dd != 0,
+                  "Run again; got aa zero random number, won't work for division")
+        continueAfterFailure = true
+
+        XCTAssertEqual(-CGPoint(x: aa, y: bb), CGPoint(x: -aa, y: -bb))
+        XCTAssertEqual(-CGSize(width: bb, height: cc), CGSize(width: -bb, height: -cc))
+        XCTAssertEqual(-CGVector(dx: cc, dy: dd), CGVector(dx: -cc, dy: -dd))
+    }
+
+    func testAsOther() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+
+        continueAfterFailure = false
+        XCTAssert(aa != 0 && bb != 0 && cc != 0 && dd != 0,
+                  "Run again; got aa zero random number, won't work for division")
+        continueAfterFailure = true
+
+        XCTAssertEqual(CGPoint(x: aa, y: bb), CGSize(width: aa, height: bb).asPoint())
+        XCTAssertEqual(CGPoint(x: aa, y: bb), CGVector(dx: aa, dy: bb).asPoint())
+
+        XCTAssertEqual(CGSize(width: bb, height: cc), CGPoint(x: bb, y: cc).asSize())
+        XCTAssertEqual(CGSize(width: bb, height: cc), CGVector(dx: bb, dy: cc).asSize())
+
+        XCTAssertEqual(CGVector(dx: cc, dy: dd), CGPoint(x: cc, y: dd).asVector())
+        XCTAssertEqual(CGVector(dx: cc, dy: dd), CGSize(width: cc, height: dd).asVector())
+    }
+
+    func testCombinations() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+
+        let pp = CGPoint(x: aa, y: bb) +
+            2 * CGVector(dx: bb, dy: cc).asPoint() -
+            (3 * CGSize(width: cc, height: dd)).asPoint()
+
+        XCTAssertEqual(pp, CGPoint(x: aa + 2 * bb - 3 * cc, y: bb + 2 * cc - 3 * dd))
+
+        let ss = CGSize(width: aa, height: bb) +
+            4 * CGVector(dx: bb, dy: cc).asSize() -
+            (5 * CGPoint(x: cc, y: dd)).asSize()
+
+        XCTAssertEqual(ss, CGSize(width: aa + 4 * bb - 5 * cc, height: bb + 4 * cc - 5 * dd))
+
+        let vv = CGVector(dx: aa, dy: bb) +
+            6 * CGSize(width: bb, height: cc).asVector() -
+            (7 * CGPoint(x: cc, y: dd)).asVector()
+
+        XCTAssertEqual(vv, CGVector(dx: aa + 6 * bb - 7 * cc, dy: bb + 6 * cc - 7 * dd))
+
+    }
+
+    func testOtherWithCombinations() {
+        let aa = CGFloat.random(in: -1000...1000)
+        let bb = CGFloat.random(in: -1000...1000)
+        let cc = CGFloat.random(in: -1000...1000)
+        let dd = CGFloat.random(in: -1000...1000)
+
+        var pp = CGPoint(x: dd, y: aa).asVector().asSize().asPoint()
+        pp *= CGPoint(x: aa, y: bb).asVector().asPoint().asSize().asPoint()
+        pp /= CGPoint(x: bb, y: cc).asSize().asPoint().asSize().asPoint()
+        pp += CGPoint(x: cc, y: dd).asSize().asVector().asPoint().asVector().asSize().asPoint()
+
+        XCTAssertEqual(pp, CGPoint(x: ((dd * aa) / bb) + cc, y: ((aa * bb) / cc) + dd))
+
+        var ss = CGSize(width: dd, height: aa).asVector().asPoint().asSize()
+        ss /= CGSize(width: aa, height: bb).asVector().asPoint().asVector().asSize()
+        ss += CGSize(width: bb, height: cc).asPoint().asVector().asPoint().asSize()
+        ss *= CGSize(width: cc, height: dd).asSize().asVector().asSize().asPoint().asVector().asSize()
+
+        XCTAssertEqual(ss, CGSize(width: ((dd / aa) + bb) * cc, height: ((aa / bb) + cc) * dd))
+
+        var vv = CGVector(dx: dd, dy: aa).asSize().asPoint().asVector()
+        vv += CGVector(dx: aa, dy: bb).asPoint().asVector().asSize().asVector()
+        vv *= CGVector(dx: bb, dy: cc).asPoint().asVector().asPoint().asVector()
+        vv /= CGVector(dx: cc, dy: dd).asSize().asVector().asPoint().asVector().asSize().asPoint().asVector()
+
+        XCTAssertEqual(vv, CGVector(dx: ((dd + aa) * bb) / cc, dy: ((aa + bb) * cc) / dd))
+    }
+}

--- a/XLSwiftKit.xcodeproj/project.pbxproj
+++ b/XLSwiftKit.xcodeproj/project.pbxproj
@@ -45,6 +45,13 @@
 		BF7E0BFF1C6E554700D831DD /* DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0BBD1C6E53E400D831DD /* DictionaryTests.swift */; };
 		BF7E0C001C6E554700D831DD /* UIColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0BBE1C6E53E400D831DD /* UIColorTests.swift */; };
 		BF7E0C011C6E554700D831DD /* GCDHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0BBF1C6E53E400D831DD /* GCDHelperTests.swift */; };
+		D489677C22495BCD000F5D15 /* Overload2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677B22495BCD000F5D15 /* Overload2D.swift */; };
+		D489678A22495C59000F5D15 /* Overload2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677B22495BCD000F5D15 /* Overload2D.swift */; };
+		D493C02A224A9EC400008149 /* TestByValue_OpScalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489678122495C38000F5D15 /* TestByValue_OpScalar.swift */; };
+		D493C02B224A9EC400008149 /* TestByReference_OpTuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677E22495C38000F5D15 /* TestByReference_OpTuple.swift */; };
+		D493C02C224A9EC400008149 /* TestByValue_OpTuple.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489677F22495C38000F5D15 /* TestByValue_OpTuple.swift */; };
+		D493C02D224A9EC400008149 /* TestMiscellaneous.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489678022495C38000F5D15 /* TestMiscellaneous.swift */; };
+		D493C02E224A9EC400008149 /* TestByReference_OpScalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D489678322495C38000F5D15 /* TestByReference_OpScalar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +106,12 @@
 		BF7E0BDA1C6E53F300D831DD /* UINavigationBar+Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Swift.h"; sourceTree = "<group>"; };
 		BF7E0BDC1C6E53F300D831DD /* XLFoundationSwiftKit-Bridgin-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XLFoundationSwiftKit-Bridgin-Header.h"; sourceTree = "<group>"; };
 		BF7E0BDD1C6E53F300D831DD /* XLFoundationSwiftKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XLFoundationSwiftKit.h; sourceTree = "<group>"; };
+		D489677B22495BCD000F5D15 /* Overload2D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Overload2D.swift; sourceTree = "<group>"; };
+		D489677E22495C38000F5D15 /* TestByReference_OpTuple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByReference_OpTuple.swift; sourceTree = "<group>"; };
+		D489677F22495C38000F5D15 /* TestByValue_OpTuple.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByValue_OpTuple.swift; sourceTree = "<group>"; };
+		D489678022495C38000F5D15 /* TestMiscellaneous.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMiscellaneous.swift; sourceTree = "<group>"; };
+		D489678122495C38000F5D15 /* TestByValue_OpScalar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByValue_OpScalar.swift; sourceTree = "<group>"; };
+		D489678322495C38000F5D15 /* TestByReference_OpScalar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestByReference_OpScalar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +164,7 @@
 		28F8288B1C494B2C00330CF4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D489677D22495C38000F5D15 /* TestOverload2D */,
 				8F52939C1D8C52BD00143015 /* DataTests.swift */,
 				BF7E0BBD1C6E53E400D831DD /* DictionaryTests.swift */,
 				BF7E0BBF1C6E53E400D831DD /* GCDHelperTests.swift */,
@@ -205,6 +219,7 @@
 				28A6B9C71CB5E28700682BCE /* NSData.swift */,
 				BF7E0BC81C6E53F300D831DD /* NSDate.swift */,
 				BF7E0BCF1C6E53F300D831DD /* Numbers.swift */,
+				D489677B22495BCD000F5D15 /* Overload2D.swift */,
 				46BD3DFD1D74CCAF00D93B2F /* ParametrizedString.swift */,
 				BF7E0BD01C6E53F300D831DD /* String.swift */,
 				BF7E0BC91C6E53F300D831DD /* UIApplication.swift */,
@@ -231,6 +246,19 @@
 			);
 			name = Helpers;
 			sourceTree = "<group>";
+		};
+		D489677D22495C38000F5D15 /* TestOverload2D */ = {
+			isa = PBXGroup;
+			children = (
+				D489677E22495C38000F5D15 /* TestByReference_OpTuple.swift */,
+				D489677F22495C38000F5D15 /* TestByValue_OpTuple.swift */,
+				D489678322495C38000F5D15 /* TestByReference_OpScalar.swift */,
+				D489678122495C38000F5D15 /* TestByValue_OpScalar.swift */,
+				D489678022495C38000F5D15 /* TestMiscellaneous.swift */,
+			);
+			name = TestOverload2D;
+			path = Tests/TestOverload2D;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
@@ -311,6 +339,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 28F828731C494B2C00330CF4;
@@ -373,6 +402,7 @@
 				46BD3DFA1D74BF8200D93B2F /* OwnerView.swift in Sources */,
 				BF7E0BEE1C6E53F300D831DD /* UIColor.swift in Sources */,
 				BF7E0BE31C6E53F300D831DD /* UIViewController.swift in Sources */,
+				D489677C22495BCD000F5D15 /* Overload2D.swift in Sources */,
 				BF68CCC21C74F2A5006BE94B /* Box.swift in Sources */,
 				BF7E0BE41C6E53F300D831DD /* AFImageExtension.swift in Sources */,
 				BF7E0BEC1C6E53F300D831DD /* Dictionary.swift in Sources */,
@@ -394,13 +424,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D493C02C224A9EC400008149 /* TestByValue_OpTuple.swift in Sources */,
 				BF7E0BFF1C6E554700D831DD /* DictionaryTests.swift in Sources */,
 				BF7E0BFC1C6E554700D831DD /* NumberTests.swift in Sources */,
 				BF7E0BFE1C6E554700D831DD /* UIImageTests.swift in Sources */,
+				D493C02B224A9EC400008149 /* TestByReference_OpTuple.swift in Sources */,
+				D493C02A224A9EC400008149 /* TestByValue_OpScalar.swift in Sources */,
 				BF7E0BFD1C6E554700D831DD /* StringTests.swift in Sources */,
 				BF7E0BFB1C6E554000D831DD /* NSDateTests.swift in Sources */,
 				BF7E0C011C6E554700D831DD /* GCDHelperTests.swift in Sources */,
 				BF7E0C001C6E554700D831DD /* UIColorTests.swift in Sources */,
+				D493C02D224A9EC400008149 /* TestMiscellaneous.swift in Sources */,
+				D493C02E224A9EC400008149 /* TestByReference_OpScalar.swift in Sources */,
+				D489678A22495C59000F5D15 /* Overload2D.swift in Sources */,
 				8F52939E1D8C530E00143015 /* DataTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XLSwiftKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/XLSwiftKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
A protocol and some extensions to the CoreGraphics 2D representations `CGPoint`, `CGSize`, and `CGVector` to enable easy conversion from one to the other, as well as arithmetic.

Functions are available for arithmetic on `CG... (op) CG...` as well as `CG... (op) CGFloat` and `CGFloat (op) CG...`.

- For the first form, `CG... (op) CG...`, the components are combined like 2D vectors:
   - `CGPoint(x: 42, y: 117) + CGPoint(x: 137, y: 9) = CGPoint(x: 42 + 137, y: 117 + 9)`
- For the second and third forms, the scalar is added to each component of the CG object:
   - `CGVector(dx: 11, dy: 21) * 5 = CGVector(dx: 11 * 5, dy: 21 * 5)`
   - `7 * CGSize(width: 3, height: 4) = CGSize(width: 7 * 3, height: 7 * 4)`

Conversion functions are available on all three types: `asPoint()`, `asSize()`, `asVector()`:
- `CGPoint(x: 10, y: 11).asSize() / 14 = CGSize(width: 10 / 14, height: 11 / 14)`
- `CGSize(width: 3, height: 4).asVector() - CGVector(dx: 4, dy: 3) = CGVector(dx: 3 - 4, dy: 4 - 3)`

Unary minus is supported; it behaves the same as with scalars, multiplying both components by -1. For example,` -CGPoint(x: 32, y: 44) = CGPoint(x -32, y: -44)`

Compound assignment is supported:

    var p = CGPoint(x: 9, y: 17)
    p *= CGPoint(104, 91) 
    precondition(p == CGPoint(x: 9 * 104, y: 17 * 91)

    var v = 21 * CGVector(dx: 7, dy: 13)
    v /= 13
    precondition(v == CGVector(dx: 21 * 7 / 13, dy: 21 * 13 / 13)